### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ import qualified Text.Blaze.Html.Renderer.Text as BT (renderHtml)
 import qualified Data.Text.Lazy as TL (Text)
 
 
-import Text.Blaze.HTML.QQ (blaze)
+import Text.Blaze.Html.QQ (blaze)
 
 test :: TL.Text
 test = BT.renderHtml [blaze|


### PR DESCRIPTION
Got :D 
```
error:
    Could not find module ‘Text.Blaze.HTML.QQ’
    Perhaps you meant Text.Blaze.Html.QQ (from blaze-html-qq-0.1.0.0)
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
  |
9 | import Text.Blaze.HTML.QQ (blaze)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```